### PR TITLE
fix: prevent empty textChange

### DIFF
--- a/src/components/Pad.tsx
+++ b/src/components/Pad.tsx
@@ -29,6 +29,8 @@ function Pad() {
 
   const [content, setContent] = useState<string>("");
 
+  const [loaded, setLoaded] = useState<boolean>(false);
+
   const [disabled, setDisabled] = useState<boolean>(false);
 
   const [onlyView, setOnlyView] = useState<boolean>(false);
@@ -43,6 +45,8 @@ function Pad() {
     const dbRef = ref(db, pathname);
 
     const unsubscribe = onValue(dbRef, (snapshot) => {
+      setLoaded(true);
+
       if (!snapshot) return;
 
       const serverDoc: ServerDoc = snapshot.val();
@@ -88,6 +92,10 @@ function Pad() {
 
   async function handleTextChange(e: ChangeEvent<HTMLTextAreaElement>) {
     const text = e.target.value;
+
+    if (!loaded) {
+      return;
+    }
 
     await handleWriting(pathname, { content: text, author: USER_ID });
   }

--- a/src/utils/writing.ts
+++ b/src/utils/writing.ts
@@ -10,7 +10,11 @@ export async function handleWriting(pathname: string, writing: Writing) {
   const dbRef = ref(db, pathname);
 
   await runTransaction(dbRef, (snapshot) => {
-    snapshot = { ...writing, updatedAt: serverTimestamp() };
+    snapshot = {
+      ...snapshot,
+      ...writing,
+      updatedAt: serverTimestamp(),
+    };
 
     return snapshot;
   });


### PR DESCRIPTION
Fix a problem that occurs when the onChange event is trigged before firebase loaded the file, causing the deletion of the node